### PR TITLE
Add delete button on pg_stat_activities

### DIFF
--- a/app/controllers/pg_stat_activities_controller.rb
+++ b/app/controllers/pg_stat_activities_controller.rb
@@ -1,11 +1,19 @@
 class PgStatActivitiesController < ApplicationController
+  protect_from_forgery with: :null_session
+
   def index
-    @pg_stat_activities = PgStatActivity.all
-    render json: @pg_stat_activities.to_json
+    pg_stat_activities = PgStatActivity.all
+    render json: pg_stat_activities.to_json
   end
 
   def show
-    @pg_stat_activity = PgStatActivity.find(params[:id])
-    render json: @pg_stat_activity.to_json
+    pg_stat_activity = PgStatActivity.find(params[:id])
+    render json: pg_stat_activity.to_json
+  end
+
+  def destroy
+    pg_stat_activity = PgStatActivity.find(params[:id])
+    pg_stat_activity.cancel_backend!
+    render json: pg_stat_activity.to_json
   end
 end

--- a/app/javascript/activity_table.vue
+++ b/app/javascript/activity_table.vue
@@ -4,18 +4,22 @@
         <table class="table-hover" v-if="data">
             <thead>
                 <tr>
-                    <th>datid</th>
-                    <th>datname</th>
-                    <th>pid</th>
-                    <th class="query_column">query</th>
+                    <th>Pid</th>
+                    <th>Datid</th>
+                    <th>Datname</th>
+                    <th>State</th>
+                    <th>Cancel Query</th>
+                    <th class="query_column">Query</th>
                 </tr>
             </thead>
             <tbody>
-                <tr v-for="(item, idx) in data">
-                    <td>{{ item.datid }}</td>
-                    <td>{{ item.datname }}</td>
-                    <td>{{ item.pid }}</td>
-                    <td class="query_column">{{ item.query }}</td>
+                <tr v-for="(activity, idx) in data">
+                    <td>{{ activity.pid }}</td>
+                    <td>{{ activity.datid }}</td>
+                    <td>{{ activity.datname }}</td>
+                    <td>{{ activity.state }}</td>
+                    <td><button @click="killActivity(activity)">Cancel Query!</button></td>
+                    <td class="query_column">{{ activity.query }}</td>
                 </tr>
             </tbody>
         </table>
@@ -25,28 +29,36 @@
 
 <script>
 export default {
-data() {
+  data() {
     return {
-        data: null
+      data: null
     };
-},
+  },
 
-mounted() {
+  mounted() {
     this.getData();
+  },
 
-},
-
-methods: {
+  methods: {
     getData() {
-        this.$http.get('pg_stat_activities.json', {responseType: 'json'}).then(response => {
-            return response.body;
-        }).then(jsonData => {
-            this.data = jsonData;
-        }).catch(e => {
-            console.log('Error', e);
-        });
+      this.$http.get('pg_stat_activities.json', {responseType: 'json'}).then(response => {
+        return response.body;
+      }).then(jsonData => {
+        this.data = jsonData;
+      }).catch(e => {
+        console.log('Error', e);
+      });
+    },
+    killActivity(activity) {
+      this.$http.delete('pg_stat_activities/' + activity.pid, {responseType: 'json'}).then(response => {
+        return response.body;
+      }).then(jsonData => {
+        this.$nextTick(this.getData);
+      }).catch(e => {
+        console.log('Error', e);
+      });
     }
-}
+  }
 }
 </script>
 
@@ -55,4 +67,10 @@ methods: {
   word-wrap: break-word;
   max-width: 400px;
 }
+.activity-table td,th {
+  padding-top:10px;
+  padding-bottom:10px;
+  padding-right:10px;
+}
+
 </style>

--- a/app/models/pg_stat_activity.rb
+++ b/app/models/pg_stat_activity.rb
@@ -1,8 +1,13 @@
 class PgStatActivity < ApplicationRecord
   self.table_name = 'pg_stat_activity'
-  self.primary_key = 'datid'
+  self.primary_key = 'pid'
 
   def readonly?
     true
+  end
+
+  def cancel_backend!
+    sql = "select pg_cancel_backend(#{pid});"
+    ActiveRecord::Base.connection.execute(sql)
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,5 @@
 Rails.application.routes.draw do
-  resources :pg_stat_activities, only: [:index, :show], defaults: { format: 'json' }
+  resources :pg_stat_activities, only: [:index, :show, :destroy], defaults: { format: 'json' }
   get 'main/index'
   root 'main#index'
 end


### PR DESCRIPTION
This button issues the `pg_cancel_backend` command on the pid that the
query is running on. This is obviously not a safe thing to run on random
queries in production. I should probably add some authentication to the
project soon.